### PR TITLE
main repo: fallback in case branch doesn't exist

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6214,7 +6214,7 @@ function getSource(settings) {
             yield authHelper.configureAuth();
             core.endGroup();
             // Determine the default branch
-            if (!settings.ref && !settings.commit) {
+            if ((!settings.ref && !settings.commit) || (settings.ref && !(yield git.remoteBranchExists(settings.ref)))) {
                 core.startGroup('Determining the default branch');
                 if (settings.sshKey) {
                     settings.ref = yield git.getDefaultBranch(repositoryUrl);

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -104,7 +104,7 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
     core.endGroup()
 
     // Determine the default branch
-    if (!settings.ref && !settings.commit) {
+    if ((!settings.ref && !settings.commit) || (settings.ref && !(await git.remoteBranchExists(settings.ref)))) {
       core.startGroup('Determining the default branch')
       if (settings.sshKey) {
         settings.ref = await git.getDefaultBranch(repositoryUrl)


### PR DESCRIPTION
Useful when checking out parent repo in children pull request and we
want to check whether a branch with the same name as the branch of the
PR exists on the parent repository.